### PR TITLE
Implement consensus safety plan

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,8 @@ ENV/
 
 # Cache directories
 .cache/
+.nicegui/
+*.pkl
 .streamlit/
 
 # IDE
@@ -35,6 +37,7 @@ htmlcov/
 .coverage
 
 # Development files
+.env
 *.log
 .pre-commit-config.yaml
 .flake8

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Required for NiceGUI server-side user storage. Generate with:
+# python -c "from secrets import token_hex; print(token_hex(32))"
+STORAGE_SECRET=change-me-to-a-long-random-value
+
+# Optional defaults
+NIGHTSCOUT_BASE_URL=https://your-nightscout.example.com
+# Legacy alias also supported:
+# CGM_SITE=https://your-nightscout.example.com
+RECENT_REQUEST_TIMEOUT=60
+LINEPLOT_HOURS=4
+DISPLAY_TIMEZONE=UTC
+TZ=UTC
+
+# Only enable these for trusted local Nightscout deployments.
+ALLOW_HTTP=0
+ALLOW_INSECURE_NS_URLS=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements.dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.dev.txt
+
+      - name: Lint
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Unit tests
+        env:
+          STORAGE_SECRET: test-secret
+        run: pytest -ra -v -m "not e2e" --cov-report=term-missing --cov=. ./tests
+
+      - name: Docker build
+        run: docker build -t sugarboard .

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,8 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
-.cache
+.cache/
+*.pkl
 nosetests.xml
 coverage.xml
 *.cover

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.1.0
+      rev: v4.6.0
       hooks:
         - id: check-added-large-files
           name: Check for added large files
@@ -35,5 +35,6 @@ repos:
         name: make-lint
         entry: make
         language: system
-        types: [make]
+        types: [python]
         args: ["lint"]
+        pass_filenames: false

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -27,6 +27,7 @@ docker build -t sugarboard:latest .
 docker run -d \
   --name sugarboard \
   -p 8080:8080 \
+  -e STORAGE_SECRET="$(python -c 'from secrets import token_hex; print(token_hex(32))')" \
   --restart unless-stopped \
   sugarboard:latest
 
@@ -121,10 +122,23 @@ environment:
   - CGM_SITE=https://your-site.herokuapp.com  # optional: pre-fills the UI form
   - STORAGE_SECRET=change-me-super-secret    # required for NiceGUI user storage
   - RECENT_REQUEST_TIMEOUT=60               # optional: bump Nightscout timeout
-  - TZ=Europe/Madrid
+  - DISPLAY_TIMEZONE=UTC
+  - TZ=UTC
+  - ALLOW_HTTP=0
+  - ALLOW_INSECURE_NS_URLS=0
+```
 
 > The Nightscout read token or API secret is entered at runtime through the dashboard's "Nightscout Connection" card; do not bake it into the container environment.
-```
+
+Keep `.env`, `.cache/`, `.nicegui/`, and exported CGM data out of git and Docker build contexts. These files can contain credentials or protected health data.
+
+### Public access
+
+Sugarboard is designed as a personal dashboard. If you expose it beyond a trusted private network, put it behind reverse-proxy authentication such as Nginx basic auth, Traefik ForwardAuth, Authelia, or an equivalent gateway. NiceGUI's password option is acceptable for a quick personal gate, but a proxy is easier to audit at the edge.
+
+### Nightscout API secret
+
+Nightscout's legacy API-secret protocol requires SHA1. Sugarboard keeps that behavior for compatibility, but read-only Nightscout tokens are preferred.
 
 ### Persistent Cache & Credentials
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Install system dependencies if needed
+# Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    tini \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
@@ -25,8 +26,14 @@ COPY nicegui_app.py .
 COPY src/ ./src/
 COPY static/ ./static/
 
-# Create cache directory
-RUN mkdir -p .cache
+# Create runtime directories and user
+RUN adduser --system --group appuser \
+    && mkdir -p .cache .nicegui \
+    && chown -R appuser:appuser /app
+
+ENV SUGARBOARD_REQUIRE_STORAGE_SECRET=1
+
+USER appuser
 
 # Expose port
 EXPOSE 8080
@@ -36,4 +43,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import requests; requests.get('http://localhost:8080/health', timeout=5)" || exit 1
 
 # Run the application
+ENTRYPOINT ["tini", "--"]
 CMD ["python", "nicegui_app.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,36 @@
-.PHONY: run lint test test-e2e install prod-install clean
+.PHONY: run lint format test test-e2e test-e2e-baseline ci coverage install prod-install clean
 
 run: install
 	NICEGUI_RELOAD=true ./venv/bin/python nicegui_app.py
 
 lint: install
+	./venv/bin/ruff check .
+	./venv/bin/ruff format --check .
+
+format: install
 	./venv/bin/ruff check --fix .
 	./venv/bin/ruff format .
 
-test: lint
-	./venv/bin/python -m pytest -ra -v -m "not e2e" --cov-report=html:coverage --cov-config=pyproject.toml --cov-report=term-missing --cov=. --cov-fail-under=5 ./tests
+test: install
+	./venv/bin/python -m pytest -ra -v -m "not e2e" --cov-report=html:coverage --cov-config=pyproject.toml --cov-report=term-missing --cov=. ./tests
 
-test-e2e: lint
+test-e2e: install
 	./venv/bin/python -m pytest -ra -v -m e2e ./tests
 
-test-e2e-baseline: lint
+test-e2e-baseline: install
 	./venv/bin/python -m pytest -ra -v -m e2e --visual-baseline ./tests
+
+ci: lint test
 
 coverage: install
 	./venv/bin/python -m http.server --bind 127.0.0.1 --directory coverage
 
 install: requirements.dev.txt
-	python -m venv venv
+	[ -d venv ] || python -m venv venv
 	./venv/bin/pip install -r requirements.dev.txt
 
 prod-install: requirements.txt
 	python -m pip install -r requirements.txt
 
 clean:
-	rm -rf __pycache__
-	rm -rf pytest_cache
-	rm -rf venv
+	rm -rf __pycache__ .pytest_cache .ruff_cache coverage htmlcov .coverage

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ docker-compose up -d --build
 
 The NiceGUI server will be exposed on [http://localhost:8080](http://localhost:8080). Logs can be tailed with `docker-compose logs -f sugarboard`, and `docker-compose down` stops the stack. The compose file also mounts a named volume to persist cached CGM data between restarts.
 
+Copy `.env.example` to `.env` first and replace `STORAGE_SECRET` with a long random value.
+
 ### Nightscout Credentials
 
 When the dashboard loads, fill in the **Nightscout Connection** card with your base URL plus either:
 
 - **Read token (recommended):** create a read-only API token inside your Nightscout instance (`Settings → API → Add Token`). This grants GET access without exposing the master secret.
-- **API secret:** the classic admin secret string (we hash it and send it via the `api-secret` header). Only use this if you have tokens disabled.
+- **API secret:** the classic admin secret string. Nightscout requires SHA1 for this legacy protocol, so Sugarboard hashes it locally and sends the hash via the `api-secret` header. Only use this if tokens are disabled.
 
 Credentials stay on the server and are never rendered back to the browser. If you set the optional `CGM_SITE` environment variable, it simply pre-fills the base URL field for convenience.
 
@@ -34,7 +36,9 @@ Credentials stay on the server and are never rendered back to the browser. If yo
 - Runtime credentials: provided through the UI card described above.
 - `STORAGE_SECRET`: required for NiceGUI's secure server-side storage (set to any long random string).
 - `RECENT_REQUEST_TIMEOUT`: Nightscout API timeout in seconds (defaults to 60). Increase if your server responds slowly.
-- `TZ`: optional timezone for the container.
+- `DISPLAY_TIMEZONE`: timezone used for dashboard timestamps (defaults to `TZ`, then `UTC`).
+- `ALLOW_HTTP`: set to `1` only for trusted local deployments that cannot use HTTPS.
+- `ALLOW_INSECURE_NS_URLS`: set to `1` only for trusted local/private Nightscout URLs.
 - Cache persistence: by default a Docker volume named `sugarboard-cache` stores `.cache/`.
 - Credential persistence: another volume `sugarboard-storage` stores `.nicegui/` so saved Nightscout credentials survive rebuilds.
 
@@ -48,6 +52,8 @@ from secrets import token_hex
 print(f"STORAGE_SECRET={token_hex(32)}")
 PY
 ```
+
+Never commit `.env`, `.cache/`, `.nicegui/`, or exported CGM data. They can contain credentials or protected health data.
 
 ## Local Development (optional, without Docker)
 
@@ -64,8 +70,8 @@ The NiceGUI app binds to `0.0.0.0:8080`. To use a different port, set `PORT=9090
 ### Developer tools
 
 ```bash
-make lint             # black, isort, flake8
-./venv/bin/pytest     # unit + integration tests (fast path)
+make lint             # ruff check + format check
+make test             # unit + integration tests (fast path)
 RUN_E2E=1 ./venv/bin/pytest -m e2e  # spins up NiceGUI + Selenium smoke tests
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   sugarboard:
     build: .
@@ -10,15 +8,23 @@ services:
     environment:
       # Add any environment variables here
       - PYTHONUNBUFFERED=1
-      - STORAGE_SECRET=${STORAGE_SECRET}
+      - STORAGE_SECRET=${STORAGE_SECRET:?STORAGE_SECRET must be set in .env}
       # Increase timeout for slow Nightscout deployments (seconds)
       - RECENT_REQUEST_TIMEOUT=${RECENT_REQUEST_TIMEOUT:-60}
+      - TZ=${TZ:-UTC}
+      - ALLOW_HTTP=${ALLOW_HTTP:-0}
+      - ALLOW_INSECURE_NS_URLS=${ALLOW_INSECURE_NS_URLS:-0}
     volumes:
       # Persist cache directory between container restarts
       - sugarboard-cache:/app/.cache
       # Persist NiceGUI user storage (Nightscout credentials, etc.)
       - sugarboard-storage:/app/.nicegui
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8080/health', timeout=5)"]
       interval: 30s

--- a/nicegui_app.py
+++ b/nicegui_app.py
@@ -4,12 +4,35 @@ import os
 from pathlib import Path
 
 from nicegui import app, ui
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.config import STORAGE_SECRET
 from src.log_setup import setup_logging
 from src.ui.pages import index_page  # noqa: F401 - Register index page
 
 setup_logging()
+
+CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data: blob:; "
+    "font-src 'self' data:; "
+    "connect-src 'self' ws: wss:; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'"
+)
+
+
+async def _security_headers(request, call_next):
+    response = await call_next(request)
+    response.headers.setdefault("Content-Security-Policy", CSP)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "no-referrer")
+    return response
+
+
+app.add_middleware(BaseHTTPMiddleware, dispatch=_security_headers)
 
 
 @ui.page("/health")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,8 @@ exclude_lines = [
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-
+testpaths = ["tests"]
+addopts = "-ra"
+markers = [
+    "e2e: mark as end-to-end test",
+]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
-ruff
-pre-commit
-pytest
-pytest-cov
-seleniumbase
-watchdog
+pre-commit>=4.0.0
+pytest-cov>=5.0.0
+pytest>=8.0.0
+ruff>=0.6.0
+seleniumbase>=4.30.0
+watchdog>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas==2.3.3
 plotly==5.24.1
 requests==2.32.5
 nicegui==2.0.0
+rich==14.2.0

--- a/src/cache.py
+++ b/src/cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import pickle
+import json
+import logging
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -10,55 +11,127 @@ import pandas as pd
 from .config import CACHE_DIR
 from .state import DataState
 
-RECENT_CACHE = CACHE_DIR / "nicegui_recent.pkl"
-HISTORICAL_CACHE = CACHE_DIR / "nicegui_historical.pkl"
+CACHE_SCHEMA_VERSION = 1
+RECENT_CACHE = CACHE_DIR / "nicegui_recent.json"
+RECENT_CACHE_META = CACHE_DIR / "nicegui_recent.meta.json"
+HISTORICAL_CACHE = CACHE_DIR / "nicegui_historical.json"
+HISTORICAL_CACHE_META = CACHE_DIR / "nicegui_historical.meta.json"
+
+RECENT_TTL_SECONDS = 24 * 60 * 60
+HISTORICAL_TTL_SECONDS = 7 * 24 * 60 * 60
 
 
-def _load_pickle(path: Path) -> Any:
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _read_json(path: Path) -> Optional[dict[str, Any]]:
     if not path.exists():
         return None
-    with open(path, "rb") as fh:
-        return pickle.load(fh)
-
-
-def _save_pickle(path: Path, data: Any) -> None:
-    with open(path, "wb") as fh:
-        pickle.dump(data, fh)
-
-
-def load_historical_cache() -> Optional[pd.DataFrame]:
-    cached = _load_pickle(HISTORICAL_CACHE)
-    if not cached:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logging.warning("Ignoring unreadable cache file %s: %s", path, exc)
         return None
-    return cached.get("df_3months")
 
 
-def save_historical_cache(df: pd.DataFrame) -> None:
-    _save_pickle(HISTORICAL_CACHE, {"df_3months": df, "cached_at": time.time()})
+def _save_meta(path: Path, *, source_url: Optional[str]) -> None:
+    _write_json(
+        path,
+        {
+            "schema_version": CACHE_SCHEMA_VERSION,
+            "source_url": source_url.rstrip("/") if source_url else None,
+            "fetched_at": time.time(),
+        },
+    )
 
 
-def load_recent_cache(state: DataState) -> None:
-    cached = _load_pickle(RECENT_CACHE)
+def _meta_is_valid(
+    path: Path,
+    *,
+    source_url: Optional[str],
+    ttl_seconds: Optional[int],
+) -> bool:
+    metadata = _read_json(path)
+    if not metadata:
+        return False
+    if metadata.get("schema_version") != CACHE_SCHEMA_VERSION:
+        return False
+    expected_source = source_url.rstrip("/") if source_url else None
+    cached_source = metadata.get("source_url")
+    if expected_source and cached_source and cached_source != expected_source:
+        return False
+    fetched_at = metadata.get("fetched_at")
+    if ttl_seconds is not None and isinstance(fetched_at, (int, float)):
+        if time.time() - fetched_at > ttl_seconds:
+            return False
+    elif ttl_seconds is not None:
+        return False
+    return True
+
+
+def _dataframe_from_json(path: Path) -> Optional[pd.DataFrame]:
+    if not path.exists():
+        return None
+    try:
+        return pd.read_json(path, orient="table")
+    except (ValueError, OSError) as exc:
+        logging.warning("Ignoring invalid dataframe cache %s: %s", path, exc)
+        return None
+
+
+def _save_dataframe(path: Path, df: pd.DataFrame) -> None:
+    df.to_json(path, orient="table", date_format="iso", index=False)
+
+
+def load_historical_cache(source_url: Optional[str] = None) -> Optional[pd.DataFrame]:
+    if not _meta_is_valid(
+        HISTORICAL_CACHE_META,
+        source_url=source_url,
+        ttl_seconds=HISTORICAL_TTL_SECONDS,
+    ):
+        return None
+    return _dataframe_from_json(HISTORICAL_CACHE)
+
+
+def save_historical_cache(df: pd.DataFrame, source_url: Optional[str] = None) -> None:
+    _save_dataframe(HISTORICAL_CACHE, df)
+    _save_meta(HISTORICAL_CACHE_META, source_url=source_url)
+
+
+def load_recent_cache(state: DataState, source_url: Optional[str] = None) -> None:
+    if not _meta_is_valid(
+        RECENT_CACHE_META,
+        source_url=source_url,
+        ttl_seconds=RECENT_TTL_SECONDS,
+    ):
+        return
+    cached = _read_json(RECENT_CACHE)
     if not cached:
         return
     state.last_value = cached.get("last_value")
     state.previous_value = cached.get("previous_value")
-    state.df_recent = cached.get("df_recent", pd.DataFrame())
+    df_recent_path = CACHE_DIR / cached.get("df_recent_file", "")
+    df_recent = _dataframe_from_json(df_recent_path)
+    state.df_recent = df_recent if df_recent is not None else pd.DataFrame()
     state.fetched_at = cached.get("fetched_at")
 
 
-def save_recent_cache(state: DataState) -> None:
+def save_recent_cache(state: DataState, source_url: Optional[str] = None) -> None:
     if state.df_recent.empty or state.last_value is None:
         return
-    _save_pickle(
+    recent_df_path = CACHE_DIR / "nicegui_recent_df.json"
+    _save_dataframe(recent_df_path, state.df_recent)
+    _write_json(
         RECENT_CACHE,
         {
             "last_value": state.last_value,
             "previous_value": state.previous_value,
-            "df_recent": state.df_recent,
+            "df_recent_file": recent_df_path.name,
             "fetched_at": state.fetched_at,
         },
     )
+    _save_meta(RECENT_CACHE_META, source_url=source_url)
 
 
 __all__ = [

--- a/src/charts.py
+++ b/src/charts.py
@@ -8,6 +8,8 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 from .config import (
+    BG_CATEGORIES,
+    DISPLAY_TIMEZONE,
     LIGHT_GREEN,
     LIGHT_RED,
     MILD_YELLOW,
@@ -87,7 +89,7 @@ def build_recent_chart(df: pd.DataFrame, theme: str = "dark") -> go.Figure:
         return create_placeholder_chart("No data yet", theme=theme)
 
     df_plot = df.copy()
-    df_plot["date"] = df_plot["date"].dt.tz_convert("Europe/Madrid").astype(str)
+    df_plot["date"] = df_plot["date"].dt.tz_convert(DISPLAY_TIMEZONE).astype(str)
     palette = _get_chart_theme(theme)
 
     fig = go.Figure()
@@ -160,20 +162,12 @@ def build_tir_chart(selected_df: pd.DataFrame, theme: str = "dark") -> go.Figure
     if selected_df.empty:
         return create_placeholder_chart("No data yet", theme=theme)
 
-    bg_categories = [
-        f"<{TARGET_SEVERE_LOW}",
-        f"{TARGET_SEVERE_LOW}-{TARGET_LOW - 1}",
-        f"{TARGET_LOW}-{TARGET_MILD_HIGH}",
-        f"{TARGET_MILD_HIGH + 1}-{TARGET_HIGH}",
-        f"{TARGET_HIGH + 1}-{TARGET_SEVERE_HIGH}",
-        f">{TARGET_SEVERE_HIGH}",
-    ]
     tir_counts = selected_df["cat_glucose"].value_counts(normalize=True)
     tir_data = pd.DataFrame(
         {
-            "cat_glucose": bg_categories,
-            "value": [tir_counts.get(cat, 0) for cat in bg_categories],
-            "percent_label": [f"{(tir_counts.get(cat, 0) * 100):.0f}%" for cat in bg_categories],
+            "cat_glucose": BG_CATEGORIES,
+            "value": [tir_counts.get(cat, 0) for cat in BG_CATEGORIES],
+            "percent_label": [f"{(tir_counts.get(cat, 0) * 100):.0f}%" for cat in BG_CATEGORIES],
         }
     )
     value_max = max(tir_data["value"].max(), 0.0001)
@@ -184,14 +178,14 @@ def build_tir_chart(selected_df: pd.DataFrame, theme: str = "dark") -> go.Figure
         y="value",
         color="cat_glucose",
         text="percent_label",
-        category_orders={"cat_glucose": bg_categories},
+        category_orders={"cat_glucose": BG_CATEGORIES},
         color_discrete_map={
-            bg_categories[0]: STRONG_RED,
-            bg_categories[1]: LIGHT_RED,
-            bg_categories[2]: LIGHT_GREEN,
-            bg_categories[3]: MILD_YELLOW,
-            bg_categories[4]: LIGHT_RED,
-            bg_categories[5]: STRONG_RED,
+            BG_CATEGORIES[0]: STRONG_RED,
+            BG_CATEGORIES[1]: LIGHT_RED,
+            BG_CATEGORIES[2]: LIGHT_GREEN,
+            BG_CATEGORIES[3]: MILD_YELLOW,
+            BG_CATEGORIES[4]: LIGHT_RED,
+            BG_CATEGORIES[5]: STRONG_RED,
         },
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from secrets import token_hex
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # Base directories
 BASE_DIR = Path(__file__).resolve().parent.parent
 CACHE_DIR = BASE_DIR / ".cache"
-CACHE_DIR.mkdir(exist_ok=True)
+CACHE_DIR.mkdir(exist_ok=True, mode=0o700)
+CACHE_DIR.chmod(0o700)
 
 
 def _int_from_env(name: str, default: int) -> int:
@@ -19,17 +21,37 @@ def _int_from_env(name: str, default: int) -> int:
 
 
 # Optional default Nightscout site (used only to prefill the UI)
-DEFAULT_NIGHTSCOUT_URL = os.environ.get("NIGHTSCOUT_BASE_URL", "")
+DEFAULT_NIGHTSCOUT_URL = os.environ.get("NIGHTSCOUT_BASE_URL") or os.environ.get("CGM_SITE", "")
 _RAW_STORAGE_SECRET = os.environ.get("STORAGE_SECRET")
 if _RAW_STORAGE_SECRET:
     STORAGE_SECRET = _RAW_STORAGE_SECRET
     STORAGE_SECRET_FROM_ENV = True
 else:
+    if os.environ.get("SUGARBOARD_REQUIRE_STORAGE_SECRET", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }:
+        raise ValueError("STORAGE_SECRET must be set when SUGARBOARD_REQUIRE_STORAGE_SECRET=1.")
     STORAGE_SECRET = token_hex(32)
     STORAGE_SECRET_FROM_ENV = False
 LINEPLOT_HOURS = _int_from_env("LINEPLOT_HOURS", 4)
 RECENT_POINTS = LINEPLOT_HOURS * 75
 RECENT_REQUEST_TIMEOUT = _int_from_env("RECENT_REQUEST_TIMEOUT", 60)
+
+_RAW_DISPLAY_TIMEZONE = os.environ.get("DISPLAY_TIMEZONE") or os.environ.get("TZ") or "UTC"
+try:
+    ZoneInfo(_RAW_DISPLAY_TIMEZONE)
+    DISPLAY_TIMEZONE = _RAW_DISPLAY_TIMEZONE
+except ZoneInfoNotFoundError:
+    DISPLAY_TIMEZONE = "UTC"
+
+ALLOW_HTTP = os.environ.get("ALLOW_HTTP", "").lower() in {"1", "true", "yes"}
+ALLOW_INSECURE_NS_URLS = os.environ.get("ALLOW_INSECURE_NS_URLS", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 
 # Glucose targets
 TARGET_SEVERE_LOW = 50
@@ -72,6 +94,9 @@ __all__ = [
     "LINEPLOT_HOURS",
     "RECENT_POINTS",
     "RECENT_REQUEST_TIMEOUT",
+    "DISPLAY_TIMEZONE",
+    "ALLOW_HTTP",
+    "ALLOW_INSECURE_NS_URLS",
     "TARGET_SEVERE_LOW",
     "TARGET_LOW",
     "TARGET_MILD_HIGH",

--- a/src/data_services.py
+++ b/src/data_services.py
@@ -89,25 +89,10 @@ def fetch_historical_data(
 
         all_data.extend(chunk_data)
 
-        if not chunk_data:
-            if raw_chunk:
-                newest_timestamp = pd.to_datetime(raw_chunk[-1]["dateString"])
-                if (
-                    isinstance(newest_timestamp, pd.Timestamp)
-                    and newest_timestamp.tzinfo is not None
-                ):
-                    newest_timestamp = newest_timestamp.tz_localize(None)
-                oldest_date = (
-                    newest_timestamp if isinstance(newest_timestamp, pd.Timestamp) else None
-                )
-            continue
-
-        newest_timestamp = pd.to_datetime(chunk_data[-1]["dateString"])
-        if isinstance(newest_timestamp, pd.Timestamp) and newest_timestamp.tzinfo is not None:
-            newest_timestamp = newest_timestamp.tz_localize(None)
+        newest_timestamp = pd.to_datetime(chunk_data[-1]["dateString"], utc=True)
         oldest_date = newest_timestamp if isinstance(newest_timestamp, pd.Timestamp) else None
 
-        target_start = pd.Timestamp.now() - pd.Timedelta(days=days)
+        target_start = pd.Timestamp.now(tz="UTC") - pd.Timedelta(days=days)
         if oldest_date is not None and oldest_date < target_start:
             break
 
@@ -115,7 +100,7 @@ def fetch_historical_data(
         raise ValueError("Nightscout returned no historical data.")
 
     df_raw = pd.DataFrame(all_data)
-    df_raw["date"] = pd.to_datetime(df_raw["dateString"])
+    df_raw["date"] = pd.to_datetime(df_raw["dateString"], utc=True)
     df_raw = df_raw[["date", "sgv", "device"]].drop_duplicates().set_index("date").sort_index()
 
     df_3months = (
@@ -158,6 +143,8 @@ def ensure_timezone_aware(df: pd.DataFrame) -> pd.DataFrame:
         raise ValueError("Dataframe missing 'date' column.")
     if not is_datetime64_any_dtype(df["date"]):
         df["date"] = pd.to_datetime(df["date"], utc=True)
+    elif getattr(df["date"].dt, "tz", None) is None:
+        df["date"] = df["date"].dt.tz_localize("UTC")
     return df
 
 

--- a/src/hero.py
+++ b/src/hero.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
-from .config import DIRECTIONS, TARGET_HIGH, TARGET_LOW
+from .config import DIRECTIONS, DISPLAY_TIMEZONE, TARGET_HIGH, TARGET_LOW
 from .data_services import ensure_timezone_aware, parse_entry_timestamp
 from .utils import strip_timezone
 
@@ -22,27 +22,27 @@ class HeroMetrics:
     streak_minutes: int
 
 
-def _calculate_in_range_streak_minutes(df_recent: pd.DataFrame) -> int:
+def _calculate_in_range_streak_minutes(df_recent: pd.DataFrame, max_gap_minutes: int = 15) -> int:
     if df_recent.empty or "date" not in df_recent or "sgv" not in df_recent:
         return 0
     try:
         df = ensure_timezone_aware(df_recent.copy()).sort_values("date")
     except Exception:
         return 0
-    last_row = df.iloc[-1]
-    if not (TARGET_LOW <= last_row["sgv"] <= TARGET_HIGH):
+    if not (TARGET_LOW <= df.iloc[-1]["sgv"] <= TARGET_HIGH):
         return 0
-    streak = 0
-    last_oor_time = df.query(f"sgv < {TARGET_LOW} or sgv > {TARGET_HIGH}")["date"]
-    if not last_oor_time.empty:
-        last_oor_timestamp = strip_timezone(last_oor_time.iloc[-1])
-        streak = int((strip_timezone(last_row["date"]) - last_oor_timestamp).total_seconds() / 60)
-    else:
-        streak = int(
-            (strip_timezone(last_row["date"]) - strip_timezone(df.iloc[0]["date"])).total_seconds()
-            / 60
-        )
 
+    streak = 0
+    rows = list(df[["date", "sgv"]].itertuples(index=False))
+    for previous, current in zip(reversed(rows[:-1]), reversed(rows[1:]), strict=False):
+        if not (TARGET_LOW <= previous.sgv <= TARGET_HIGH):
+            break
+        gap_minutes = int(
+            (strip_timezone(current.date) - strip_timezone(previous.date)).total_seconds() / 60
+        )
+        if gap_minutes < 0 or gap_minutes > max_gap_minutes:
+            break
+        streak += gap_minutes
     return streak
 
 
@@ -50,7 +50,7 @@ def calculate_hero_metrics(
     last_entry: Optional[Dict[str, Any]],
     previous_entry: Optional[Dict[str, Any]],
     df_recent: pd.DataFrame,
-    local_timezone: str = "Europe/Madrid",
+    local_timezone: str = DISPLAY_TIMEZONE,
 ) -> Optional[HeroMetrics]:
     if last_entry is None:
         return None

--- a/src/nightscout_client.py
+++ b/src/nightscout_client.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 
 class NightscoutClient:
@@ -20,9 +22,24 @@ class NightscoutClient:
         self.base_url = base_url.rstrip("/")
         self.token = token or None
         self.timeout = timeout
+        self.session = requests.Session()
+        retry = Retry(
+            total=3,
+            connect=3,
+            read=3,
+            backoff_factor=0.5,
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=frozenset({"GET"}),
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
 
         self.api_secret_hash = None
         if not self.token and api_secret:
+            # Nightscout's legacy API-secret protocol requires SHA1.
+            # Prefer read-only tokens for new configurations.
             self.api_secret_hash = hashlib.sha1(api_secret.encode("utf-8")).hexdigest()
 
     def _build_url(self, path: str) -> str:
@@ -41,7 +58,7 @@ class NightscoutClient:
         req_params = dict(params or {})
         auth_params, headers = self._auth_params_headers()
         req_params.update(auth_params)
-        response = requests.get(
+        response = self.session.get(
             self._build_url(path),
             params=req_params,
             headers=headers,

--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import ipaddress
+import logging
+import socket
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
+from urllib.parse import urlparse, urlunparse
 
 from nicegui import app, ui
 
-from src.config import DEFAULT_NIGHTSCOUT_URL, STORAGE_SECRET_FROM_ENV
+from src.config import (
+    ALLOW_HTTP,
+    ALLOW_INSECURE_NS_URLS,
+    DEFAULT_NIGHTSCOUT_URL,
+    RECENT_REQUEST_TIMEOUT,
+    STORAGE_SECRET_FROM_ENV,
+)
 from src.nightscout_client import NightscoutClient
 
 
@@ -19,20 +29,70 @@ class NightscoutRefs:
 
 
 CACHED_CREDENTIAL_PLACEHOLDER = "[saved credential]"
-RECENT_REQUEST_TIMEOUT = (
-    10  # Imported from nicegui_app or config? It was in nicegui_app imports but also config.
-)
-# checking imports in nicegui_app.py: RECENT_REQUEST_TIMEOUT from src.config
 
 
 def _sanitize_base_url(value: str) -> str:
-    return value.strip().rstrip("/")
+    raw_value = value.strip().rstrip("/")
+    if not raw_value:
+        return ""
+    if "://" not in raw_value:
+        raw_value = f"https://{raw_value}"
+
+    parsed = urlparse(raw_value)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Nightscout URL must use http or https.")
+    if parsed.scheme == "http" and not ALLOW_HTTP:
+        raise ValueError("Nightscout URL must use https unless ALLOW_HTTP=1 is set.")
+    if parsed.scheme == "http":
+        logging.warning("ALLOW_HTTP enabled; Nightscout traffic is not encrypted.")
+    if not parsed.hostname:
+        raise ValueError("Nightscout URL is missing a host.")
+    if parsed.username or parsed.password:
+        raise ValueError("Nightscout URL must not include embedded credentials.")
+    if _host_is_private(parsed.hostname) and not ALLOW_INSECURE_NS_URLS:
+        raise ValueError(
+            "Nightscout URL points to a private/local address. "
+            "Set ALLOW_INSECURE_NS_URLS=1 only for trusted local deployments."
+        )
+
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", ""))
+
+
+def _host_is_private(hostname: str) -> bool:
+    if hostname.lower() in {"localhost", "localhost.localdomain"}:
+        return True
+    addresses: set[str] = set()
+    try:
+        addresses.add(str(ipaddress.ip_address(hostname)))
+    except ValueError:
+        try:
+            addresses.update(info[4][0] for info in socket.getaddrinfo(hostname, None))
+        except socket.gaierror:
+            return False
+
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return True
+    return False
 
 
 def get_client_from_storage() -> Optional[NightscoutClient]:
     storage = app.storage.user
     base_url = storage.get("ns_base_url")
     if not base_url:
+        return None
+    try:
+        base_url = _sanitize_base_url(base_url)
+    except ValueError as exc:
+        logging.warning("Ignoring invalid Nightscout URL from storage: %s", exc)
         return None
     token = storage.get("ns_token") or None
     api_secret = storage.get("ns_api_secret") or None
@@ -123,7 +183,11 @@ def render_nightscout_settings_card(
             ).classes("text-xs text-slate-400 mb-5 leading-relaxed")
 
         def save_settings() -> None:
-            base = _sanitize_base_url(base_input.value or "")
+            try:
+                base = _sanitize_base_url(base_input.value or "")
+            except ValueError as exc:
+                ui.notify(str(exc), type="warning")
+                return
             raw_token = (token_input.value or "").strip()
             raw_secret = (secret_input.value or "").strip()
 

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -41,7 +41,7 @@ from src.ui.components import (
     render_nightscout_settings_card,
     render_storage_secret_callout,
 )
-from src.utils import mean_glucose_to_hba1c, strip_timezone
+from src.utils import mean_glucose_to_gmi, strip_timezone
 
 STATE = DataState()
 
@@ -81,7 +81,7 @@ class UIRefs:
 
 async def ensure_historical_data(client: NightscoutClient, refs: Optional[Any] = None) -> None:
     """Load or fetch the 90-day historical dataset."""
-    cached_df = load_historical_cache()
+    cached_df = load_historical_cache(source_url=client.base_url)
     if cached_df is not None:
         logging.info(f"✓ Loaded {len(cached_df)} historical records from cache")
         STATE.df_3months = cached_df
@@ -105,7 +105,7 @@ async def ensure_historical_data(client: NightscoutClient, refs: Optional[Any] =
 
     df_3months = await fetch_historical_async(client, 90, progress_update)
     STATE.df_3months = df_3months
-    save_historical_cache(df_3months)
+    save_historical_cache(df_3months, source_url=client.base_url)
     logging.info(f"✓ Fetched and cached {len(df_3months)} historical records")
 
 
@@ -118,7 +118,7 @@ async def refresh_recent_data(client: NightscoutClient, full_refresh: bool = Fal
         STATE.previous_value = previous_value
         STATE.df_recent = df_recent
         STATE.fetched_at = time.time()
-        save_recent_cache(STATE)
+        save_recent_cache(STATE, source_url=client.base_url)
         return
 
     latest_entry = await asyncio.to_thread(fetch_latest_entry, client)
@@ -158,7 +158,7 @@ async def refresh_recent_data(client: NightscoutClient, full_refresh: bool = Fal
     STATE.previous_value = previous_value
     STATE.df_recent = df_recent
     STATE.fetched_at = time.time()
-    save_recent_cache(STATE)
+    save_recent_cache(STATE, source_url=client.base_url)
 
 
 def update_hero(refs: UIRefs) -> None:
@@ -254,8 +254,8 @@ def update_summary_cards(refs: UIRefs) -> None:
     else:
         refs.avg_label.text = f"{average_glucose:.0f} mg/dL"
         refs.mmol_label.text = f"{average_glucose * 0.0555:.1f} mmol/L"
-        hba1c_value = mean_glucose_to_hba1c(average_glucose)
-        refs.hba1c_label.text = f"{hba1c_value:.1f}%"
+        gmi_value = mean_glucose_to_gmi(average_glucose)
+        refs.hba1c_label.text = f"{gmi_value:.1f}%"
 
     refs.dataset_label.text = f"{records_selected:,} records"
     refs.hypo_label.text = f"Hypo events: {hypo_events}"
@@ -460,9 +460,7 @@ def build_dashboard_ui(
         with ui.card().classes(
             "flex-1 min-w-[200px] bg-slate-900 border border-slate-700 shadow-lg flex flex-col"
         ):
-            ui.label("EST_HbA1c").classes(
-                "text-xs uppercase tracking-widest text-slate-400 font-bold"
-            )
+            ui.label("GMI").classes("text-xs uppercase tracking-widest text-slate-400 font-bold")
             hba1c_label = ui.label("--").classes("text-2xl font-bold text-slate-100")
         with ui.card().classes(
             "flex-1 min-w-[200px] bg-slate-900 border border-slate-700 shadow-lg flex flex-col"
@@ -475,7 +473,7 @@ def build_dashboard_ui(
 
     # Recent glucose - full width
     with ui.card().classes("w-full bg-slate-900 border border-slate-700 shadow-lg"):
-        ui.label("RECENT GLUCOSE · Last 4 Hours").classes(
+        ui.label(f"RECENT GLUCOSE · Last {LINEPLOT_HOURS} Hours").classes(
             "text-xs uppercase tracking-widest text-slate-400 font-bold mb-0"
         )
         recent_chart = ui.plotly(

--- a/src/ui/pages.py
+++ b/src/ui/pages.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 import pandas as pd
 from nicegui import app, ui
 
+from src.config import BASE_DIR
 from src.data_services import ensure_timezone_aware
 from src.ui.components import get_client_from_storage
 from src.ui.dashboard import (
@@ -25,6 +26,22 @@ from src.ui.dashboard import (
 )
 from src.ui.theme import DEFAULT_THEME, THEME_STORAGE_KEY, set_active_theme
 from src.utils import strip_timezone
+
+
+def _safe_fixture_data_dir(raw_path: str) -> Optional[Path]:
+    requested = Path(raw_path).expanduser().resolve()
+    allowed_roots = [
+        (BASE_DIR / "tests").resolve(),
+        (BASE_DIR / "fixtures").resolve(),
+    ]
+    for root in allowed_roots:
+        try:
+            requested.relative_to(root)
+        except ValueError:
+            continue
+        return requested
+    logging.warning("Rejected SUGARBOARD_TEST_DATA_DIR outside test fixture roots: %s", requested)
+    return None
 
 
 @ui.page("/")
@@ -76,7 +93,7 @@ async def index_page() -> None:
             await asyncio.to_thread(lambda: client.get_sgv(count=1))
         except Exception as exc:
             prefill_verification_pending = False
-            # User-friendly error mapping
+            logging.exception("Nightscout connection verification failed")
             err_msg = str(exc)
             if "HTTPSConnectionPool" in err_msg or "Failed to resolve" in err_msg:
                 user_msg = "Could not reach server. Check URL."
@@ -85,7 +102,7 @@ async def index_page() -> None:
             elif "timeout" in err_msg.lower():
                 user_msg = "Connection timed out."
             else:
-                user_msg = f"Connection failed: {exc}"
+                user_msg = "Connection failed. Check logs for details."
 
             connection_refs.status_label.text = user_msg
             connection_refs.status_dot.set_visibility(True)
@@ -165,7 +182,9 @@ async def index_page() -> None:
             data_dir_env = os.environ.get("SUGARBOARD_TEST_DATA_DIR")
             if not data_dir_env:
                 return False
-            data_dir = Path(data_dir_env)
+            data_dir = _safe_fixture_data_dir(data_dir_env)
+            if data_dir is None:
+                return False
             recent_path = data_dir / "recent.json"
             history_path = data_dir / "history.json"
             if not recent_path.exists() or not history_path.exists():
@@ -217,16 +236,6 @@ async def index_page() -> None:
             if await try_load_fixture_data():
                 return
 
-            # Note: load_recent_cache logic assumes modules are imported.
-            # It was imported from nicegui_app but needs to be imported here or handled in dashboard logic.
-            # It is not imported in this file yet! I need to import load_recent_cache.
-            # Wait, I imported load_initial_data logic but missed importing load_recent_cache at top.
-            # I will assume I need to import it.
-            # Checking imports... no load_recent_cache imported.
-            from src.cache import load_recent_cache
-
-            load_recent_cache(STATE)
-
             client = get_client_from_storage()
             if client is None:
                 prefill_verification_pending = False
@@ -234,21 +243,26 @@ async def index_page() -> None:
                 await type_status("$ waiting --nightscout-config")
                 return
 
+            from src.cache import load_recent_cache
+
+            load_recent_cache(STATE, source_url=client.base_url)
+
             await type_status("$ fetch --historical --days=90")
             refs.pattern_status.text = "⏳ Loading from cache/API..."
             await ensure_historical_data(client, refs)
 
             if not STATE.df_3months.empty:
-                cache_path = Path(".cache/nicegui_historical.pkl")
-                if cache_path.exists():
-                    cache_age = time.time() - cache_path.stat().st_mtime
+                from src.cache import HISTORICAL_CACHE
+
+                if HISTORICAL_CACHE.exists():
+                    cache_age = time.time() - HISTORICAL_CACHE.stat().st_mtime
                     refs.pattern_status.text = f"✓ Cached ({int(cache_age / 60)}m old) · {len(STATE.df_3months):,} records"
                 else:
                     refs.pattern_status.text = (
                         f"✓ Fetched from API · {len(STATE.df_3months):,} records"
                     )
 
-            await type_status("$ fetch --recent --hours=4")
+            await type_status("$ fetch --recent")
 
             client = get_client_from_storage()
             if client is None:
@@ -278,11 +292,12 @@ async def index_page() -> None:
             refs.status_container.classes(
                 remove="status-terminal-text", add="status-terminal-muted"
             )
-        except Exception as exc:
+        except Exception:
             prefill_verification_pending = False
-            refs.pattern_status.text = f"✗ Error: {exc}"
-            await type_status(f"$ error -- {exc}")
-            connection_refs.status_label.text = f"Connection failed: {exc}"
+            logging.exception("Initial dashboard load failed")
+            refs.pattern_status.text = "✗ Load failed. Check logs for details."
+            await type_status("$ error -- check logs")
+            connection_refs.status_label.text = "Connection failed. Check logs for details."
             connection_refs.status_dot.set_visibility(True)
             connection_refs.status_dot.classes(
                 remove="hidden connection-dot-active connection-dot-pending",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,9 @@
 import pandas as pd
 
 
-def mean_glucose_to_hba1c(g: float) -> float:
+def mean_glucose_to_gmi(g: float) -> float:
     """
-    Computes the estimated Hba1C (or GMI) as defined in Bergenstal et al (doi: 10.2337/dc18-1581)
+    Compute glucose management indicator (GMI) as defined in Bergenstal et al.
 
     Parameters
     ----------
@@ -13,9 +13,14 @@ def mean_glucose_to_hba1c(g: float) -> float:
     Returns
     -------
     float
-    Estimated Hba1c (in %).
+    GMI (in %).
     """
     return 3.31 + 0.02395 * g
+
+
+def mean_glucose_to_hba1c(g: float) -> float:
+    """Backward-compatible alias for callers not yet migrated to GMI naming."""
+    return mean_glucose_to_gmi(g)
 
 
 def strip_timezone(ts: pd.Timestamp) -> pd.Timestamp:
@@ -25,4 +30,4 @@ def strip_timezone(ts: pd.Timestamp) -> pd.Timestamp:
     return ts
 
 
-__all__ = ["mean_glucose_to_hba1c", "strip_timezone"]
+__all__ = ["mean_glucose_to_gmi", "mean_glucose_to_hba1c", "strip_timezone"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Iterator
@@ -17,9 +18,11 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "e2e: mark as end-to-end test")
 
 
-def _wait_for_health(url: str, timeout: float = 25.0) -> None:
+def _wait_for_health(url: str, proc: subprocess.Popen, timeout: float = 25.0) -> None:
     start = time.time()
     while time.time() - start < timeout:
+        if proc.poll() is not None:
+            raise RuntimeError(f"NiceGUI server exited early with code {proc.returncode}")
         try:
             response = requests.get(url, timeout=1.0)
             if response.status_code == 200:
@@ -44,9 +47,12 @@ def nicegui_server() -> Iterator[str]:
     env.setdefault("NICEGUI_RELOAD", "0")
 
     cmd = [sys.executable, "nicegui_app.py"]
-    proc = subprocess.Popen(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    log_file = tempfile.NamedTemporaryFile(
+        mode="w+", prefix="sugarboard-e2e-", suffix=".log", delete=False
+    )
+    proc = subprocess.Popen(cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
     try:
-        _wait_for_health(f"http://localhost:{port}/health")
+        _wait_for_health(f"http://localhost:{port}/health", proc)
         yield f"http://localhost:{port}"
     finally:
         proc.terminate()
@@ -54,3 +60,4 @@ def nicegui_server() -> Iterator[str]:
             proc.wait(timeout=10)
         except subprocess.TimeoutExpired:
             proc.kill()
+        log_file.close()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,65 @@
+import time
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from src import cache
+from src.state import DataState
+
+
+def _patch_cache_paths(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "RECENT_CACHE", tmp_path / "recent.json")
+    monkeypatch.setattr(cache, "RECENT_CACHE_META", tmp_path / "recent.meta.json")
+    monkeypatch.setattr(cache, "HISTORICAL_CACHE", tmp_path / "historical.json")
+    monkeypatch.setattr(cache, "HISTORICAL_CACHE_META", tmp_path / "historical.meta.json")
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+
+
+def test_historical_cache_round_trips_with_matching_source(monkeypatch, tmp_path):
+    _patch_cache_paths(monkeypatch, tmp_path)
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2026-01-01", periods=2, freq="5min", tz="UTC"),
+            "sgv": [100, 105],
+            "cat_glucose": ["70-150", "70-150"],
+        }
+    )
+
+    cache.save_historical_cache(df, source_url="https://nightscout.example")
+    loaded = cache.load_historical_cache(source_url="https://nightscout.example")
+
+    assert loaded is not None
+    assert_frame_equal(loaded, df, check_dtype=False)
+
+
+def test_historical_cache_rejects_mismatched_source(monkeypatch, tmp_path):
+    _patch_cache_paths(monkeypatch, tmp_path)
+    df = pd.DataFrame({"date": pd.date_range("2026-01-01", periods=1, tz="UTC"), "sgv": [100]})
+
+    cache.save_historical_cache(df, source_url="https://one.example")
+
+    assert cache.load_historical_cache(source_url="https://two.example") is None
+
+
+def test_recent_cache_rejects_expired_metadata(monkeypatch, tmp_path):
+    _patch_cache_paths(monkeypatch, tmp_path)
+    monkeypatch.setattr(cache, "RECENT_TTL_SECONDS", 1)
+    state = DataState(
+        last_value={"sgv": 100, "dateString": "2026-01-01T00:00:00Z"},
+        previous_value={"sgv": 99, "dateString": "2025-12-31T23:55:00Z"},
+        df_recent=pd.DataFrame(
+            {"date": pd.date_range("2026-01-01", periods=1, tz="UTC"), "sgv": [100]}
+        ),
+        fetched_at=time.time(),
+    )
+
+    cache.save_recent_cache(state, source_url="https://nightscout.example")
+    metadata = cache._read_json(cache.RECENT_CACHE_META)
+    metadata["fetched_at"] = time.time() - 10
+    cache._write_json(cache.RECENT_CACHE_META, metadata)
+
+    restored = DataState()
+    cache.load_recent_cache(restored, source_url="https://nightscout.example")
+
+    assert restored.last_value is None
+    assert restored.df_recent.empty

--- a/tests/test_data_services.py
+++ b/tests/test_data_services.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from src.data_services import ensure_timezone_aware, fetch_recent_data
+
+
+class FakeClient:
+    def get_sgv(self, count):
+        now = pd.Timestamp.now(tz="UTC")
+        return [
+            {
+                "dateString": now.isoformat(),
+                "sgv": 110,
+                "device": "test",
+            },
+            {
+                "dateString": (now - pd.Timedelta(minutes=5)).isoformat(),
+                "sgv": 100,
+                "device": "test",
+            },
+        ]
+
+
+def test_ensure_timezone_aware_localizes_naive_dates():
+    df = pd.DataFrame({"date": [pd.Timestamp("2026-01-01 00:00:00")], "sgv": [100]})
+
+    result = ensure_timezone_aware(df)
+
+    assert result["date"].dt.tz is not None
+    assert str(result["date"].dt.tz) == "UTC"
+
+
+def test_fetch_recent_data_normalizes_to_utc():
+    last_value, previous_value, df_recent = fetch_recent_data(FakeClient())
+
+    assert last_value["sgv"] == 110
+    assert previous_value["sgv"] == 100
+    assert df_recent["date"].dt.tz is not None

--- a/tests/test_hero_metrics.py
+++ b/tests/test_hero_metrics.py
@@ -35,3 +35,26 @@ def test_streak_zero_when_out_of_range():
     prev_row = df.iloc[-2]
     metrics = calculate_hero_metrics(_make_entry(last_row), _make_entry(prev_row), df)
     assert metrics.streak_minutes == 0
+
+
+def test_streak_does_not_cross_large_data_gap():
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(
+                [
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:05:00Z",
+                    "2026-01-01T02:00:00Z",
+                ],
+                utc=True,
+            ),
+            "sgv": [100, 105, 110],
+            "device": ["xDrip", "xDrip", "xDrip"],
+        }
+    )
+    last_row = df.iloc[-1]
+    prev_row = df.iloc[-2]
+
+    metrics = calculate_hero_metrics(_make_entry(last_row), _make_entry(prev_row), df)
+
+    assert metrics.streak_minutes == 0

--- a/tests/test_nightscout_client.py
+++ b/tests/test_nightscout_client.py
@@ -1,0 +1,40 @@
+import hashlib
+
+import pytest
+from requests.adapters import HTTPAdapter
+
+from src.nightscout_client import NightscoutClient
+from src.ui import components
+
+
+def test_api_secret_hash_uses_nightscout_sha1_protocol():
+    client = NightscoutClient("https://nightscout.example", api_secret="secret")
+
+    assert client.api_secret_hash == hashlib.sha1(b"secret").hexdigest()
+
+
+def test_client_configures_retrying_http_adapters():
+    client = NightscoutClient("https://nightscout.example")
+    adapter = client.session.get_adapter("https://nightscout.example")
+
+    assert isinstance(adapter, HTTPAdapter)
+    assert adapter.max_retries.total == 3
+    assert 503 in adapter.max_retries.status_forcelist
+
+
+def test_sanitize_base_url_defaults_to_https():
+    assert components._sanitize_base_url("nightscout.example/") == "https://nightscout.example"
+
+
+def test_sanitize_base_url_rejects_http_without_opt_in(monkeypatch):
+    monkeypatch.setattr(components, "ALLOW_HTTP", False)
+
+    with pytest.raises(ValueError, match="https"):
+        components._sanitize_base_url("http://nightscout.example")
+
+
+def test_sanitize_base_url_rejects_private_addresses(monkeypatch):
+    monkeypatch.setattr(components, "ALLOW_INSECURE_NS_URLS", False)
+
+    with pytest.raises(ValueError, match="private/local"):
+        components._sanitize_base_url("https://127.0.0.1")


### PR DESCRIPTION
## Summary

Implements the concrete, low-judgment items from the Sugarboard consensus plan:

- replaces unsafe pickle cache files with JSON dataframe caches plus sidecar metadata, TTL checks, source URL validation, and restrictive cache permissions
- adds Nightscout client retries, HTTPS/private-address URL validation, generic UI error messages, configurable display timezone, and CSP/security headers
- hardens Docker with a non-root runtime user, `tini`, required `STORAGE_SECRET`, expanded ignore rules, and compose resource limits
- fixes pre-commit/Makefile/CI configuration and adds `.env.example`
- renames the displayed estimated HbA1c metric to GMI, derives the recent chart label from config, and tightens timestamp/streak behavior
- adds focused tests for cache behavior, URL validation, retry setup, timestamp normalization, and streak gaps

## Validation

- `./venv/bin/ruff format --check . && ./venv/bin/ruff check .`
- `./venv/bin/python -m pytest -ra -v -m "not e2e" --cov-report=term-missing --cov=. ./tests` passed before commit: 21 passed, 2 e2e deselected
- `./venv/bin/python -m compileall nicegui_app.py src tests`
- `./venv/bin/python -c "import nicegui_app; print('ok')"`
- `STORAGE_SECRET=dummy docker compose --env-file .env.example config --quiet`

## Notes

Docker build was not completed locally because the Docker daemon was not running. The previous 5% coverage gate was removed rather than raised prematurely; whole-repo coverage is still around 28% because the large NiceGUI UI modules remain mostly untested.